### PR TITLE
fix: conflict when using uuid with, the ID is sanitized without harmi…

### DIFF
--- a/src/composables/useBarSelector.ts
+++ b/src/composables/useBarSelector.ts
@@ -14,7 +14,7 @@ export default function useBarSelector() {
     const ganttContainer = document.getElementById(ganttId)
     if (!ganttContainer) return null
 
-    return ganttContainer.querySelector(`#${barId}`) as HTMLElement
+    return ganttContainer.querySelector(`#${CSS.escape(barId)}`) as HTMLElement
   }
 
   /**


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/52597662-ec29-4a2d-b9ff-0ce04030755d)
With some types of ID the querySelector does not work correctly, I propose this solution
from:
```typescript
return ganttContainer.querySelector(`#${barId}`) as HTMLElement
```
to:
```typescript
return ganttContainer.querySelector(`#${CSS.escape(barId)}`) as HTMLElement
```