### PR TITLE
fix: horizontal scroll while scrolling in the Y axis

### DIFF
--- a/src/composables/useChartNavigation.ts
+++ b/src/composables/useChartNavigation.ts
@@ -66,7 +66,11 @@ export function useChartNavigation(options: ChartNavigationOptions, maxRows: num
   }
 
   /**
-   * Handles mouse wheel event for scrolling
+   * Handles mouse wheel event for horizontal scrolling.
+   * Only responds to explicit horizontal input (deltaX).
+   * Pure vertical scrolls (deltaX === 0) are ignored so the browser
+   * can handle them as normal page scroll.
+   *
    * @param e - Mouse wheel event
    * @param wrapper - Container DOM element
    */
@@ -78,7 +82,12 @@ export function useChartNavigation(options: ChartNavigationOptions, maxRows: num
       return
     }
 
-    wrapper.scrollLeft += e.deltaX || e.deltaY
+    if (e.deltaX === 0) {
+      return
+    }
+
+    e.preventDefault()
+    wrapper.scrollLeft += e.deltaX
     const maxScroll = totalWidth.value - wrapper.clientWidth
     scrollPosition.value = (wrapper.scrollLeft / maxScroll) * 100
   }

--- a/tests/composables/useChartNavigation.test.ts
+++ b/tests/composables/useChartNavigation.test.ts
@@ -202,19 +202,35 @@ describe("useChartNavigation", () => {
       expect(navigation.scrollPosition.value).toBe(40)
     })
 
-    it("should use deltaY when deltaX is not available", () => {
+    it("should ignore pure vertical scroll and let the browser handle page scroll", () => {
       const navigation = useChartNavigation(mockOptions, 0)
       const wrapper = createMockElement({ clientWidth: 200 })
 
-      const wheelEvent = new WheelEvent("wheel", { 
+      const wheelEvent = new WheelEvent("wheel", {
         deltaX: 0,
         deltaY: 75
       })
 
       navigation.handleWheel(wheelEvent, wrapper)
 
-      expect(wrapper.scrollLeft).toBe(75)
-      expect(navigation.scrollPosition.value).toBe(30) // (75/250) * 100
+      expect(wrapper.scrollLeft).toBe(0)
+      expect(navigation.scrollPosition.value).toBe(0)
+    })
+
+    it("should prevent default on horizontal scroll when maxRows is 0", () => {
+      const navigation = useChartNavigation(mockOptions, 0)
+      const wrapper = createMockElement({ clientWidth: 200 })
+
+      const wheelEvent = new WheelEvent("wheel", {
+        deltaX: 100,
+        deltaY: 0,
+        cancelable: true
+      })
+      const preventDefaultSpy = vi.spyOn(wheelEvent, "preventDefault")
+
+      navigation.handleWheel(wheelEvent, wrapper)
+
+      expect(preventDefaultSpy).toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
# Pull Request

## Description

handleWheel in useChartNavigation.ts uses e.deltaX || e.deltaY to update wrapper.scrollLeft. When the user scrolls vertically (mouse wheel or trackpad), deltaX is 0 (falsy), so the expression falls through to deltaY, which gets applied as horizontal scroll. This causes the chart viewport to shift left unexpectedly during normal vertical page scrolling.

The fix changes handleWheel to only apply deltaX to scrollLeft and return early when deltaX === 0, allowing the
browser to handle pure vertical scrolls as normal page scroll.

Fixes #21

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I added this chunk of code to my project component and it worked, so I guess i can contribute with the fix:

```js
function handleGanttWheel (e: WheelEvent) {
  if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
    e.stopPropagation();
  }
}

onMounted(() => {
  baseGantRef.value?.addEventListener('wheel', handleGanttWheel, { capture: true });
});
```

  - Updated existing unit test that was asserting the buggy behavior ("should use deltaY when deltaX is not available")
  to now verify that pure vertical scroll is ignored (scrollLeft stays at 0)
  - Added new test verifying preventDefault is called on horizontal scroll when maxRows is 0
  - Full test suite passes locally (443 passed, 27 skipped, 0 failures)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional context

The bug only manifests when maxRows is 0 (the default when the prop is not set). When maxRows !== 0, the handler already returns early, which is why this wasn't caught before. The fix is minimal: replacing e.deltaX || e.deltaY with an early return on deltaX === 0 and using e.deltaX directly.
